### PR TITLE
Nested and arbitrary sorting and empty data pagination controls error

### DIFF
--- a/src/re_frame_datatable/core.cljs
+++ b/src/re_frame_datatable/core.cljs
@@ -1,4 +1,4 @@
-(ns st.views.re-frame-datatable
+(ns re-frame-datatable.core
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame :refer [trim-v]]


### PR DESCRIPTION
Fixes sorting to a) work with nested data paths, b) to sort on values other than the column-key value, and c) to avoid failing to render when the data subscription is empty because the default-pagination-controls component throws an error.